### PR TITLE
do not put the cursor in the 'valid' state when rewinding if it's emp…

### DIFF
--- a/src/MongoCursor.php
+++ b/src/MongoCursor.php
@@ -688,6 +688,8 @@ class MongoCursor implements Iterator
     public function rewind()
     {
         $this->currKey = 0;
-        $this->end = false;
+        if (count($this->documents) > 0) {
+            $this->end = false;
+        }
     }
 }

--- a/tests/Mongofill/Tests/Integration/Standalone/MongoCursorTest.php
+++ b/tests/Mongofill/Tests/Integration/Standalone/MongoCursorTest.php
@@ -180,6 +180,15 @@ class MongoCursorTest extends TestCase
         $this->assertSame(500, $this->coll->find()->limit(10)->count());
     }
 
+    public function testEmptyRewind()
+    {
+        $result = $this->coll->find();
+        $this->assertCount(0, $result);
+
+        $result->rewind();
+        $this->assertCount(0, $result);
+    }
+
     public function testReset()
     {
         $this->createNDocuments(500);


### PR DESCRIPTION
…ty (fixes #86)
